### PR TITLE
Building postgresql with e2fs to provide support for uuid-ossp extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install libssl-dev -y && \
     apt-get install libreadline6 libreadline6-dev && \
     apt-get install libxml2-dev -y && \
+    apt-get install uuid-dev -y && \
     mkdir -p /usr/lib/postgresql/9.6/ && \
-    ./configure --with-openssl --with-libxml --prefix=/usr/lib/postgresql/9.6/ && \
+    ./configure --with-openssl --with-libxml --with-uuid=e2fs --prefix=/usr/lib/postgresql/9.6/ && \
     export CPUS=$(grep -c ^processor /proc/cpuinfo) && \
     make -j${CPUS} world && make install-world && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
`uuid-ossp` extension of PostgreSQL depends upon `libuuid` library. Also, while configuring  PostgreSQL source code, it is needed to pass `--with-uuid=e2fs` so that it Postgres knows about the uuid library.